### PR TITLE
[ISSUE-01]  Fixed copy & paste error so that the secret key is properly set

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,7 @@ sudo ntpdate ntp.ubuntu.com
 
 echo 'Configuring based on parameters...'
 aws configure set aws_access_key_id $WERCKER_INSTALL_AWS_CLI_KEY
-aws configure set aws_access_key_id $WERCKER_INSTALL_AWS_CLI_SECRET
+aws configure set aws_secret_access_key $WERCKER_INSTALL_AWS_CLI_SECRET
 if [ -n "$WERCKER_INSTALL_AWS_CLI_REGION" ]; then
   aws configure set default.region $WERCKER_INSTALL_AWS_CLI_REGION
 fi

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: install-aws-cli
-version: 0.0.4
+version: 0.0.5
 description: Install AWS Command Line Tools
 properties:
   key:


### PR DESCRIPTION
In the previous version, it looks like there was a copy and paste error where the same AWS configuration key was being set twice.  This pull request addresses that issue.
