### PR TITLE
Installing libpython-dev

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,6 +21,9 @@ sudo apt-get update
 echo 'Installing Unzip...'
 sudo apt-get install unzip -y
 
+echo 'Installing libpython-dev...'
+sudo apt-get install libpython-dev -y
+
 echo 'Grabbing AWS CLI...'
 wget https://s3.amazonaws.com/aws-cli/awscli-bundle.zip
 unzip awscli-bundle.zip


### PR DESCRIPTION
Installing libpython-dev so that versions > 1.11.18 builds properly